### PR TITLE
Updated stippler.py as Scipy deprecated imread.

### DIFF
--- a/code/stippler.py
+++ b/code/stippler.py
@@ -45,6 +45,7 @@ import os.path
 import scipy.misc
 import scipy.ndimage
 import numpy as np
+import imageio
 
 def normalize(D):
     Vmin, Vmax = D.min(), D.max()
@@ -135,7 +136,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     filename = args.filename
-    density = scipy.misc.imread(filename, flatten=True, mode='L')
+    density = imageio.imread(filename, as_gray=True, pilmode='L')
 
     # We want (approximately) 500 pixels per voronoi region
     zoom = (args.n_point * 500) / (density.shape[0]*density.shape[1])


### PR DESCRIPTION
Repo Branch fails as scipy.imread is deprecated. Followed instructions in scipy here: https://docs.scipy.org/doc/scipy-1.2.1/reference/generated/scipy.misc.imread.html to use Image.io. Imageio docs have article on how to transition from scipy, and I followed those steps: https://imageio.readthedocs.io/en/stable/scipy.html?highlight=flatten#transitioning-from-scipy-s-imread. 
Love your work.

<!-- Please title your PR with all author's name -->
<!-- Two spaces at the end of a line = new line -->

**AUTHOR**

Dear @ReScience/editors,

I request a review for the following replication:

### Original article

**Title:**  
**Author(s):**  
**Journal (or Conference):**  
**Year:**  
**DOI:**  
**PDF:**   

### Replication

**Author(s)**:   
**Repository**:  
**PDF**:  
**Keywords**:  
**Language**:  
**Domain**:  

### Results

* [ ] Article has been fully replicated
* [ ] Article has been partially replicated
* [ ] Article has not been replicated


### Potential reviewers
<!-- If you know potential reviewers, you can tell us here -->
<!-- You can look at http://rescience.github.io/board for the -->
<!-- list of registered reviewers (but you can propose others) -->


---

**EDITOR**

* [ ] Editor acknowledgment
* [ ] Reviewer 1 
* [ ] Reviewer 2
* [ ] Review 1 decision [accept/reject]
* [ ] Review 2 decision [accept/reject]
* [ ] Editor decision [accept/reject]
